### PR TITLE
Add support for non-CC:T versions

### DIFF
--- a/CC-OS-ComputerCraft-Tweaked/assets/computercraft/lua/bios.lua
+++ b/CC-OS-ComputerCraft-Tweaked/assets/computercraft/lua/bios.lua
@@ -88,15 +88,28 @@ if _VERSION == "Lua 5.1" then
         loadstring = function(string, chunkname) return nativeloadstring(string, prefix( chunkname )) end
 
         -- Inject a stub for the old bit library
-        _G.bit = {
-            bnot = bit32.bnot,
-            band = bit32.band,
-            bor = bit32.bor,
-            bxor = bit32.bxor,
-            brshift = bit32.arshift,
-            blshift = bit32.lshift,
-            blogic_rshift = bit32.rshift
-        }
+        if bit then
+            local nativebit = bit
+            bit32 = {}
+            bit32.arshift = nativebit.brshift
+            bit32.band = nativebit.band
+            bit32.bnot = nativebit.bnot
+            bit32.bor = nativebit.bor
+            bit32.btest = function( a, b ) return nativebit.band(a,b) ~= 0 end
+            bit32.bxor = nativebit.bxor
+            bit32.lshift = nativebit.blshift
+            bit32.rshift = nativebit.blogic_rshift
+        else
+            _G.bit = {
+                bnot = bit32.bnot,
+                band = bit32.band,
+                bor = bit32.bor,
+                bxor = bit32.bxor,
+                brshift = bit32.arshift,
+                blshift = bit32.lshift,
+                blogic_rshift = bit32.rshift
+            }
+        end
     end
 end
 


### PR DESCRIPTION
Vanilla ComputerCraft 1.8 and CraftOS-PC provide the `bit` library and have the BIOS create the `bit32` library, while CC: Tweaked provides the `bit32` library and creates the CC `bit` library in the BIOS. This PR fixes support on systems that have `bit` but not `bit32`.